### PR TITLE
Use promise for the PUSHER_OPTS resolution

### DIFF
--- a/app/initializers/pusher.js
+++ b/app/initializers/pusher.js
@@ -4,17 +4,25 @@ import { Controller } from 'ember-pusher/controller';
 
 export function initialize(container, app) {
   container.register('pusher:main', Controller);
-  var options = ENV['APP']['PUSHER_OPTS'];
+  var promise = ENV['APP']['PUSHER_OPTS'];
+  
+   Ember.assert('Pusher library is required', typeof window.Pusher !== 'undefined');
+  
+  if (!(promise instanceof Ember.RSVP.Promise)) {
+    promise = new Ember.RSVP.Promise(function(resolve) {
+      Ember.assert('Define PUSHER_OPTS in your config', typeof promise !== 'undefined');
+      resolve(promise);
+    })
+  }
+  
+  promise.then(function(options) {
+    var pusher = new window.Pusher(options.key, options.connection);
+    var pusherController = container.lookup('pusher:main');
+    pusherController.didCreatePusher(pusher);
 
-  Ember.assert('Define PUSHER_OPTS in your config', typeof options !== 'undefined');
-  Ember.assert('Pusher library is required', typeof window.Pusher !== 'undefined');
-
-  var pusher = new window.Pusher(options.key, options.connection);
-  var pusherController = container.lookup('pusher:main');
-  pusherController.didCreatePusher(pusher);
-
-  app.inject('controller', 'pusher', 'pusher:main');
-  app.inject('route', 'pusher', 'pusher:main');
+    app.inject('controller', 'pusher', 'pusher:main');
+    app.inject('route', 'pusher', 'pusher:main');
+  });
 }
 
 export default {


### PR DESCRIPTION
I'm in the situation of wanting to dynamically load the pusher config from my API server. As it was originally coded, you had to only declare in environment.js. Now, if you want to create a pre-initializer for pusher, you can! It just has to set PUSHER_OPTS to be a Promise, and we'll now resolve it before continuing on with initialization.

You can see how this is used in our app: https://github.com/wordset/wordset-ui/blob/master/app/initializers/pusher-configure.js