### PR TITLE
update pusher import path

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    this.app.import(app.bowerDirectory + '/pusher/dist/pusher.js');
+    this.app.import(app.bowerDirectory + '/pusher/dist/web/pusher.js');
     this.app.import(app.bowerDirectory + '/ember-pusher/ember-pusher.amd.js', {
       exports: {
         'ember-pusher/controller':    ['Controller'],


### PR DESCRIPTION
The latest release of pusher-js moved `dist/pusher.js` to `dist/web/pusher.js`: https://github.com/pusher/pusher-js/tree/v3.1.0/dist